### PR TITLE
feat: add input system

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ LDFLAGS  := -L lib/SFML-2.5.1/lib -lsfml-graphics -lsfml-window -lsfml-system
 CXXFLAGS := -I lib/SFML-2.5.1/include
 SRCDIR   := src
 OBJDIR   := bin
-MAIN_OBJ_REQS := $(OBJDIR)/main.o $(OBJDIR)/entity.o $(OBJDIR)/text-component-system.o $(OBJDIR)/event.o
+MAIN_OBJ_REQS := $(OBJDIR)/main.o $(OBJDIR)/entity.o $(OBJDIR)/text-component-system.o $(OBJDIR)/event.o $(OBJDIR)/main-menu.o $(OBJDIR)/input-event-dispatcher.o
 
 $(OBJDIR)/main: $(MAIN_OBJ_REQS) $(OBJDIR)
 	g++ -o $(OBJDIR)/main $(MAIN_OBJ_REQS) $(LDFLAGS)

--- a/src/confirm-input-event.hpp
+++ b/src/confirm-input-event.hpp
@@ -1,0 +1,16 @@
+#ifndef CONFIRM_INPUT_EVENT_H
+#define CONFIRM_INPUT_EVENT_H
+
+#include "event.hpp"
+
+using DescriptorType = const char*;
+
+class ConfirmInputEvent : public Event
+{
+public:
+	ConfirmInputEvent() = default;
+	static constexpr DescriptorType descriptor = "ConfirmInputEvent";
+	virtual DescriptorType type() const { return descriptor; }
+};
+
+#endif // CONFIRM_INPUT_EVENT_H

--- a/src/input-event-dispatcher.cpp
+++ b/src/input-event-dispatcher.cpp
@@ -1,0 +1,87 @@
+#include "confirm-input-event.hpp"
+#include "event.hpp"
+#include "input-event-dispatcher.hpp"
+#include <iostream>
+
+void InputEventDispatcher::dispatchEvent(sf::Event &event)
+{
+	switch (event.type)
+	{
+		case sf::Event::KeyPressed:
+			if (_isKeyNumber(event.key.code))
+			{
+				PickedTile pickedTile = _numKeyToPickedTile(event.key.code);
+				PickedTileInputEvent pickedTileInputEvent(pickedTile);
+				Dispatcher::getInstance().post(pickedTileInputEvent);
+			} else if (event.key.code == sf::Keyboard::Enter)
+			{
+				ConfirmInputEvent confirmInputEvent;
+				Dispatcher::getInstance().post(confirmInputEvent);
+			}
+			break;
+		default: break;
+	}
+}
+
+PickedTile InputEventDispatcher::_numKeyToPickedTile(sf::Keyboard::Key code)
+{
+	switch (code)
+	{
+		case sf::Keyboard::Num1:
+		case sf::Keyboard::Numpad1:
+			return PickedTile::topLeft;
+        case sf::Keyboard::Num2:
+		case sf::Keyboard::Numpad2:
+			return PickedTile::topCenter;
+        case sf::Keyboard::Num3:
+		case sf::Keyboard::Numpad3:
+			return PickedTile::topRight;
+        case sf::Keyboard::Num4:
+		case sf::Keyboard::Numpad4:
+			return PickedTile::centerLeft;
+        case sf::Keyboard::Num5:
+		case sf::Keyboard::Numpad5:
+			return PickedTile::center;
+        case sf::Keyboard::Num6:
+		case sf::Keyboard::Numpad6:
+			return PickedTile::centerRight;
+        case sf::Keyboard::Num7:
+		case sf::Keyboard::Numpad7:
+			return PickedTile::bottomLeft;
+        case sf::Keyboard::Num8:
+		case sf::Keyboard::Numpad8:
+			return PickedTile::bottomCenter;
+        case sf::Keyboard::Num9:
+		case sf::Keyboard::Numpad9:
+			return PickedTile::bottomRight;
+		default:
+			throw "Cannot convert sf::Keyboard::Key to PickedTile.";
+	}
+};
+
+bool InputEventDispatcher::_isKeyNumber(sf::Keyboard::Key code)
+{
+	switch (code)
+	{
+		case sf::Keyboard::Num1:
+        case sf::Keyboard::Num2:
+        case sf::Keyboard::Num3:
+        case sf::Keyboard::Num4:
+        case sf::Keyboard::Num5:
+        case sf::Keyboard::Num6:
+        case sf::Keyboard::Num7:
+        case sf::Keyboard::Num8:
+        case sf::Keyboard::Num9:
+		case sf::Keyboard::Numpad1:
+		case sf::Keyboard::Numpad2:
+		case sf::Keyboard::Numpad3:
+		case sf::Keyboard::Numpad4:
+		case sf::Keyboard::Numpad5:
+		case sf::Keyboard::Numpad6:
+		case sf::Keyboard::Numpad7:
+		case sf::Keyboard::Numpad8:
+		case sf::Keyboard::Numpad9:
+			return true;
+		default: return false;
+	}
+}

--- a/src/input-event-dispatcher.hpp
+++ b/src/input-event-dispatcher.hpp
@@ -1,0 +1,17 @@
+#ifndef INPUT_EVENT_DISPATCHER_H
+#define INPUT_EVENT_DISPATCHER_H
+
+#include "picked-tile-input-event.hpp"
+#include <functional>
+#include <SFML/Window.hpp>
+
+class InputEventDispatcher
+{
+public:
+	InputEventDispatcher() = default;
+	void dispatchEvent(sf::Event &event);
+private:
+	bool _isKeyNumber(sf::Keyboard::Key code);
+	PickedTile _numKeyToPickedTile(sf::Keyboard::Key code);
+};
+#endif // INPUT_EVENT_DISPATCHER_H

--- a/src/main-menu.cpp
+++ b/src/main-menu.cpp
@@ -1,0 +1,37 @@
+#include "confirm-input-event.hpp"
+#include "main-menu.hpp"
+#include "text-component-system.hpp"
+#include <iostream>
+
+void MainMenu::_handleConfirmInputEvent(const Event& event)
+{
+	const ConfirmInputEvent& confirmInputEvent = static_cast<const ConfirmInputEvent&>(event);
+	std::cout << "Quick, start the game, now!" << std::endl;
+}
+
+// UPGRADE: instead of passing the window object so that MainMenu can
+// horizontally center the main menu title text, pass an option to the
+// TextComponent to keep it horizontally centered. The TextComponentSystem
+// already has a reference to the window in order to render things.
+MainMenu::MainMenu(sf::RenderWindow &window)
+{
+	_title = new Entity();
+	auto& titleText {_title->addComponent<TextComponent>()};
+	titleText.sfmlText.setString("Tic-Tac-Toe");
+	titleText.sfmlText.setOrigin(titleText.sfmlText.getLocalBounds().width / 2.0f, 0.0f);
+	titleText.sfmlText.setPosition(static_cast<float>(window.getSize().x) / 2.0f, 20.0f);
+
+	Entity *startTextEntity = new Entity();
+	TextComponent& startText = startTextEntity->addComponent<TextComponent>();
+	startText.sfmlText.setString("Press enter to start (under construction)");
+	startText.sfmlText.setCharacterSize(18);
+	startText.sfmlText.setOrigin(startText.sfmlText.getLocalBounds().width / 2.0f, 0);
+	startText.sfmlText.setPosition(
+		static_cast<float>(window.getSize().x) / 2.0f,
+		titleText.sfmlText.getPosition().y + titleText.sfmlText.getLocalBounds().height + 20.0f);
+
+	Dispatcher::getInstance().subscribe(
+			ConfirmInputEvent::descriptor,
+			std::bind(&MainMenu::_handleConfirmInputEvent, this, std::placeholders::_1));
+}
+

--- a/src/main-menu.hpp
+++ b/src/main-menu.hpp
@@ -1,0 +1,18 @@
+#ifndef MAIN_MENU_H
+
+#include "entity.hpp"
+#include "event.hpp"
+#include <SFML/Graphics.hpp>
+
+class MainMenu
+{
+public:
+	MainMenu(sf::RenderWindow &window);
+private:
+	Entity *_title;
+	Entity *_startText;
+	void _handleConfirmInputEvent(const Event& event);
+};
+
+#define MAIN_MENU_H
+#endif // MAIN_MENU_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,28 +1,18 @@
-#include "entity.hpp"
+#include "main-menu.hpp"
 #include "text-component-system.hpp"
+#include "input-event-dispatcher.hpp"
 #include <iostream>
 
 int main()
 {
 	sf::RenderWindow window(sf::VideoMode(800, 600), "Tic-Tac-Toe");
+	window.setKeyRepeatEnabled(false);
 
 	// Initialize systems.
 	TextComponentSystem textComponentSystem;
+	InputEventDispatcher inputEventDispatcher;
 
-	// Create title screen.
-	Entity *titleEntity = new Entity();
-	auto& titleText {titleEntity->addComponent<TextComponent>()};
-	titleText.sfmlText.setString("Tic-Tac-Toe");
-	titleText.sfmlText.setOrigin(titleText.sfmlText.getLocalBounds().width / 2.0f, 0.0f);
-	titleText.sfmlText.setPosition(static_cast<float>(window.getSize().x) / 2.0f, 20.0f);
-	Entity *startTextEntity = new Entity();
-	TextComponent& startText = startTextEntity->addComponent<TextComponent>();
-	startText.sfmlText.setString("Press enter to start (under construction)");
-	startText.sfmlText.setCharacterSize(18);
-	startText.sfmlText.setOrigin(startText.sfmlText.getLocalBounds().width / 2.0f, 0);
-	startText.sfmlText.setPosition(
-		static_cast<float>(window.getSize().x) / 2.0f,
-		titleText.sfmlText.getPosition().y + titleText.sfmlText.getLocalBounds().height + 20.0f);
+	MainMenu mainMenu(window);
 
 	// Game loop.
 	while (window.isOpen())
@@ -32,6 +22,8 @@ int main()
 		{
 			if (event.type == sf::Event::Closed)
 				window.close();
+
+			inputEventDispatcher.DispatchEvent(event);
 		}
 
 		window.clear(sf::Color::Black);

--- a/src/picked-tile-input-event.hpp
+++ b/src/picked-tile-input-event.hpp
@@ -1,0 +1,32 @@
+#ifndef PICKED_TILE_INPUT_EVENT_H
+#define PICKED_TILE_INPUT_EVENT_H
+
+#include "event.hpp"
+
+using DescriptorType = const char*;
+
+enum PickedTile
+{
+	topLeft,
+	topCenter,
+	topRight,
+	centerLeft,
+	center,
+	centerRight,
+	bottomLeft,
+	bottomCenter,
+	bottomRight
+};
+
+class PickedTileInputEvent : public Event
+{
+private:
+	PickedTile _pickedTile;
+public:
+	PickedTileInputEvent(PickedTile pickedTile) : _pickedTile(pickedTile) {}
+	PickedTile pickedTile() const { return _pickedTile; }
+	static constexpr DescriptorType descriptor {"PickedTileInputEvent"};
+	virtual DescriptorType type() const { return descriptor; }
+};
+
+#endif // PICKED_TILE_INPUT_EVENT_H


### PR DESCRIPTION
refactor: add main menu class

The main menu code that creates entities to render itself can now
conveniently be found in a main menu class.

feat: dispatch normal events from sfml window events

Now, when sfml input events come in through the window object, event
objects are fired via the event Dispatcher to anyone who's listening.
This means that subscribers to input events do not need a reference to
the sfml window object.

A cost of this approach is that the input events are received by all
subscribers, instead of being consumed by the highest priority
subscriber. So potentially two subscribers could perform actions at the
same time if they are listening to the same input event, but that's an
okay cost for this game. I don't think there will be a time when two
different systems are subscribed to the same input event.